### PR TITLE
various nit's and fixes for UBSan/MSan and clang-5.0 compatibility (Linux x86_64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,10 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# Generated object files
+*.o
+
+# Generated binaries
+arith_test
+kex_test

--- a/AMD64/fp_x64_gas_asm.S
+++ b/AMD64/fp_x64_gas_asm.S
@@ -1,0 +1,1990 @@
+// SIDH: an efficient supersingular isogeny-based cryptography library for
+//       ephemeral Diffie-Hellman key exchange.
+//
+//    Copyright (c) Microsoft Corporation. All rights reserved.
+//
+//
+// Abstract: field arithmetic in x64 assembly for Linux
+
+// p751 + 1
+#define p751p1_5	0xEEB0000000000000
+#define p751p1_6	0xE3EC968549F878A8
+#define p751p1_7	0xDA959B1A13F7CC76
+#define p751p1_8	0x084E9867D6EBE876
+#define p751p1_9	0x8562B5045CB25748
+#define p751p1_10	0x0E12909F97BADC66
+#define p751p1_11	0x00006FE5D541F71C
+
+#define p751x2_0	0xFFFFFFFFFFFFFFFE
+#define p751x2_1	0xFFFFFFFFFFFFFFFF
+#define p751x2_5	0xDD5FFFFFFFFFFFFF
+#define p751x2_6	0xC7D92D0A93F0F151
+#define p751x2_7	0xB52B363427EF98ED
+#define p751x2_8	0x109D30CFADD7D0ED
+#define p751x2_9	0x0AC56A08B964AE90
+#define p751x2_10	0x1C25213F2F75B8CD
+#define p751x2_11	0x0000DFCBAA83EE38
+
+//  Field addition
+//  Operation: c [%rdx] = a [%rdi] + b [%rsi]
+.globl	fpadd751_asm
+fpadd751_asm:
+	pushq	%r12
+	pushq	%r13
+	pushq	%r14
+	pushq	%r15
+
+	movq	(%rdi),%r8
+	movq	8(%rdi),%r9
+	movq	16(%rdi),%r10
+	movq	24(%rdi),%r11
+	movq	32(%rdi),%r12
+	movq	40(%rdi),%r13
+	movq	48(%rdi),%r14
+	movq	56(%rdi),%r15
+	movq	64(%rdi),%rcx
+	addq	(%rsi),%r8
+	adcq	8(%rsi),%r9
+	adcq	16(%rsi),%r10
+	adcq	24(%rsi),%r11
+	adcq	32(%rsi),%r12
+	adcq	40(%rsi),%r13
+	adcq	48(%rsi),%r14
+	adcq	56(%rsi),%r15
+	adcq	64(%rsi),%rcx
+	movq	72(%rdi),%rax
+	adcq	72(%rsi),%rax
+	movq	%rax,72(%rdx)
+	movq	80(%rdi),%rax
+	adcq	80(%rsi),%rax
+	movq	%rax,80(%rdx)
+	movq	88(%rdi),%rax
+	adcq	88(%rsi),%rax
+	movq	%rax,88(%rdx)
+
+	movq	$p751x2_0,%rax
+	subq	%rax,%r8
+	movq	$p751x2_1,%rax
+	sbbq	%rax,%r9
+	sbbq	%rax,%r10
+	sbbq	%rax,%r11
+	sbbq	%rax,%r12
+	movabs	$p751x2_5,%rax
+	sbbq	%rax,%r13
+	movabs	$p751x2_6,%rax
+	sbbq	%rax,%r14
+	movabs	$p751x2_7,%rax
+	sbbq	%rax,%r15
+	movabs	$p751x2_8,%rax
+	sbbq	%rax,%rcx
+	movq	%r8,(%rdx)
+	movq	%r9,8(%rdx)
+	movq	%r10,16(%rdx)
+	movq	%r11,24(%rdx)
+	movq	%r12,32(%rdx)
+	movq	%r13,40(%rdx)
+	movq	%r14,48(%rdx)
+	movq	%r15,56(%rdx)
+	movq	%rcx,64(%rdx)
+	movq	72(%rdx),%r8
+	movq	80(%rdx),%r9
+	movq	88(%rdx),%r10
+	movabs	$p751x2_9,%rax
+	sbbq	%rax,%r8
+	movabs	$p751x2_10,%rax
+	sbbq	%rax,%r9
+	movabs	$p751x2_11,%rax
+	sbbq	%rax,%r10
+	movq	%r8,72(%rdx)
+	movq	%r9,80(%rdx)
+	movq	%r10,88(%rdx)
+	movq	$0,%rax
+	sbbq	$0,%rax
+
+	movq	$p751x2_0,%rsi
+	andq	%rax,%rsi
+	movq	$p751x2_1,%r8
+	andq	%rax,%r8
+	movabs	$p751x2_5,%r9
+	andq	%rax,%r9
+	movabs	$p751x2_6,%r10
+	andq	%rax,%r10
+	movabs	$p751x2_7,%r11
+	andq	%rax,%r11
+	movabs	$p751x2_8,%r12
+	andq	%rax,%r12
+	movabs	$p751x2_9,%r13
+	andq	%rax,%r13
+	movabs	$p751x2_10,%r14
+	andq	%rax,%r14
+	movabs	$p751x2_11,%r15
+	andq	%rax,%r15
+
+	movq	(%rdx),%rax
+	addq	%rsi,%rax
+	movq	%rax,(%rdx)
+	movq	8(%rdx),%rax
+	adcq	%r8,%rax
+	movq	%rax,8(%rdx)
+	movq	16(%rdx),%rax
+	adcq	%r8,%rax
+	movq	%rax,16(%rdx)
+	movq	24(%rdx),%rax
+	adcq	%r8,%rax
+	movq	%rax,24(%rdx)
+	movq	32(%rdx),%rax
+	adcq	%r8,%rax
+	movq	%rax,32(%rdx)
+	movq	40(%rdx),%rax
+	adcq	%r9,%rax
+	movq	%rax,40(%rdx)
+	movq	48(%rdx),%rax
+	adcq	%r10,%rax
+	movq	%rax,48(%rdx)
+	movq	56(%rdx),%rax
+	adcq	%r11,%rax
+	movq	%rax,56(%rdx)
+	movq	64(%rdx),%rax
+	adcq	%r12,%rax
+	movq	%rax,64(%rdx)
+	movq	72(%rdx),%rax
+	adcq	%r13,%rax
+	movq	%rax,72(%rdx)
+	movq	80(%rdx),%rax
+	adcq	%r14,%rax
+	movq	%rax,80(%rdx)
+	movq	88(%rdx),%rax
+	adcq	%r15,%rax
+	movq	%rax,88(%rdx)
+
+	popq	%r15
+	popq	%r14
+	popq	%r13
+	popq	%r12
+	retq
+.size	fpadd751_asm,.-fpadd751_asm
+
+
+//  Field subtraction
+//  Operation: c [%rdx] = a [%rdi] - b [%rsi]
+.globl	fpsub751_asm
+fpsub751_asm:
+	pushq	%r12
+	pushq	%r13
+	pushq	%r14
+	pushq	%r15
+
+	movq	(%rdi),%r8
+	movq	8(%rdi),%r9
+	movq	16(%rdi),%r10
+	movq	24(%rdi),%r11
+	movq	32(%rdi),%r12
+	movq	40(%rdi),%r13
+	movq	48(%rdi),%r14
+	movq	56(%rdi),%r15
+	movq	64(%rdi),%rcx
+	subq	(%rsi),%r8
+	sbbq	8(%rsi),%r9
+	sbbq	16(%rsi),%r10
+	sbbq	24(%rsi),%r11
+	sbbq	32(%rsi),%r12
+	sbbq	40(%rsi),%r13
+	sbbq	48(%rsi),%r14
+	sbbq	56(%rsi),%r15
+	sbbq	64(%rsi),%rcx
+	movq	%r8,(%rdx)
+	movq	%r9,8(%rdx)
+	movq	%r10,16(%rdx)
+	movq	%r11,24(%rdx)
+	movq	%r12,32(%rdx)
+	movq	%r13,40(%rdx)
+	movq	%r14,48(%rdx)
+	movq	%r15,56(%rdx)
+	movq	%rcx,64(%rdx)
+	movq	72(%rdi),%rax
+	sbbq	72(%rsi),%rax
+	movq	%rax,72(%rdx)
+	movq	80(%rdi),%rax
+	sbbq	80(%rsi),%rax
+	movq	%rax,80(%rdx)
+	movq	88(%rdi),%rax
+	sbbq	88(%rsi),%rax
+	movq	%rax,88(%rdx)
+	movq	$0,%rax
+	sbbq	$0,%rax
+
+	movq	$p751x2_0,%rsi
+	andq	%rax,%rsi
+	movq	$p751x2_1,%r8
+	andq	%rax,%r8
+	movabs	$p751x2_5,%r9
+	andq	%rax,%r9
+	movabs	$p751x2_6,%r10
+	andq	%rax,%r10
+	movabs	$p751x2_7,%r11
+	andq	%rax,%r11
+	movabs	$p751x2_8,%r12
+	andq	%rax,%r12
+	movabs	$p751x2_9,%r13
+	andq	%rax,%r13
+	movabs	$p751x2_10,%r14
+	andq	%rax,%r14
+	movabs	$p751x2_11,%r15
+	andq	%rax,%r15
+
+	movq	(%rdx),%rax
+	addq	%rsi,%rax
+	movq	%rax,(%rdx)
+	movq	8(%rdx),%rax
+	adcq	%r8,%rax
+	movq	%rax,8(%rdx)
+	movq	16(%rdx),%rax
+	adcq	%r8,%rax
+	movq	%rax,16(%rdx)
+	movq	24(%rdx),%rax
+	adcq	%r8,%rax
+	movq	%rax,24(%rdx)
+	movq	32(%rdx),%rax
+	adcq	%r8,%rax
+	movq	%rax,32(%rdx)
+	movq	40(%rdx),%rax
+	adcq	%r9,%rax
+	movq	%rax,40(%rdx)
+	movq	48(%rdx),%rax
+	adcq	%r10,%rax
+	movq	%rax,48(%rdx)
+	movq	56(%rdx),%rax
+	adcq	%r11,%rax
+	movq	%rax,56(%rdx)
+	movq	64(%rdx),%rax
+	adcq	%r12,%rax
+	movq	%rax,64(%rdx)
+	movq	72(%rdx),%rax
+	adcq	%r13,%rax
+	movq	%rax,72(%rdx)
+	movq	80(%rdx),%rax
+	adcq	%r14,%rax
+	movq	%rax,80(%rdx)
+	movq	88(%rdx),%rax
+	adcq	%r15,%rax
+	movq	%rax,88(%rdx)
+
+	popq	%r15
+	popq	%r14
+	popq	%r13
+	popq	%r12
+	retq
+.size	fpsub751_asm,.-fpsub751_asm
+
+
+//  Integer multiplication
+//  Based on Karatsuba method
+//  Operation: c [%rdx] = a [%rdi] * b [%rsi]
+//  NOTE: a=c or b=c are not allowed
+.globl	mul751_asm
+mul751_asm:
+	pushq	%r12
+	pushq	%r13
+	pushq	%r14
+
+	movq	%rdx,%rcx
+	xorq	%rax,%rax
+	movq	48(%rdi),%r8
+	movq	56(%rdi),%r9
+	movq	64(%rdi),%r10
+	movq	72(%rdi),%r11
+	movq	80(%rdi),%r12
+	movq	88(%rdi),%r13
+	addq	(%rdi),%r8
+	adcq	8(%rdi),%r9
+	adcq	16(%rdi),%r10
+	adcq	24(%rdi),%r11
+	adcq	32(%rdi),%r12
+	adcq	40(%rdi),%r13
+	pushq	%r15
+	movq	%r8,(%rcx)
+	movq	%r9,8(%rcx)
+	movq	%r10,16(%rcx)
+	movq	%r11,24(%rcx)
+	movq	%r12,32(%rcx)
+	movq	%r13,40(%rcx)
+	sbbq	$0,%rax
+	subq	$96,%rsp					// Allocating space in stack
+
+	xorq	%rdx,%rdx
+	movq	48(%rsi),%r8
+	movq	56(%rsi),%r9
+	movq	64(%rsi),%r10
+	movq	72(%rsi),%r11
+	movq	80(%rsi),%r12
+	movq	88(%rsi),%r13
+	addq	(%rsi),%r8
+	adcq	8(%rsi),%r9
+	adcq	16(%rsi),%r10
+	adcq	24(%rsi),%r11
+	adcq	32(%rsi),%r12
+	adcq	40(%rsi),%r13
+	movq	%r8,48(%rcx)
+	movq	%r9,56(%rcx)
+	movq	%r10,64(%rcx)
+	movq	%r11,72(%rcx)
+	movq	%r12,80(%rcx)
+	movq	%r13,88(%rcx)
+	sbbq	$0,%rdx
+	movq	%rax,80(%rsp)
+	movq	%rdx,88(%rsp)
+
+// (rsp[0-8],r10,r8,r9) <- (AH+AL)*(BH+BL)
+	movq	(%rcx),%r11
+	movq	%r8,%rax
+	mulq	%r11
+	movq	%rax,(%rsp)				// c0
+	movq	%rdx,%r14
+
+	xorq	%r15,%r15
+	movq	%r9,%rax
+	mulq	%r11
+	xorq	%r9,%r9
+	addq	%rax,%r14
+	adcq	%rdx,%r9
+
+	movq	8(%rcx),%r12
+	movq	%r8,%rax
+	mulq	%r12
+	addq	%rax,%r14
+	movq	%r14,8(%rsp)			// c1
+	adcq	%rdx,%r9
+	adcq	$0,%r15
+
+	xorq	%r8,%r8
+	movq	%r10,%rax
+	mulq	%r11
+	addq	%rax,%r9
+	movq	48(%rcx),%r13
+	adcq	%rdx,%r15
+	adcq	$0,%r8
+
+	movq	16(%rcx),%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r15
+	movq	56(%rcx),%rax
+	adcq	$0,%r8
+
+	mulq	%r12
+	addq	%rax,%r9
+	movq	%r9,16(%rsp)			// c2
+	adcq	%rdx,%r15
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movq	72(%rcx),%rax
+	mulq	%r11
+	addq	%rax,%r15
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	24(%rcx),%rax
+	mulq	%r13
+	addq	%rax,%r15
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	%r10,%rax
+	mulq	%r12
+	addq	%rax,%r15
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	16(%rcx),%r14
+	movq	56(%rcx),%rax
+	mulq	%r14
+	addq	%rax,%r15
+	movq	%r15,24(%rsp)			// c3
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	xorq	%r10,%r10
+	movq	80(%rcx),%rax
+	mulq	%r11
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	64(%rcx),%rax
+	mulq	%r14
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	48(%rcx),%r15
+	movq	32(%rcx),%rax
+	mulq	%r15
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	72(%rcx),%rax
+	mulq	%r12
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	24(%rcx),%r13
+	movq	56(%rcx),%rax
+	mulq	%r13
+	addq	%rax,%r8
+	movq	%r8,32(%rsp)			// c4
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movq	88(%rcx),%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	64(%rcx),%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	72(%rcx),%rax
+	mulq	%r14
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	40(%rcx),%rax
+	mulq	%r15
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	80(%rcx),%rax
+	mulq	%r12
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	32(%rcx),%r15
+	movq	56(%rcx),%rax
+	mulq	%r15
+	addq	%rax,%r9
+	movq	%r9,40(%rsp)			// c5
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movq	64(%rcx),%rax
+	mulq	%r15
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	88(%rcx),%rax
+	mulq	%r12
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	80(%rcx),%rax
+	mulq	%r14
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	40(%rcx),%r11
+	movq	56(%rcx),%rax
+	mulq	%r11
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	72(%rcx),%rax
+	mulq	%r13
+	addq	%rax,%r10
+	movq	%r10,48(%rsp)			// c6
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	xorq	%r10,%r10
+	movq	88(%rcx),%rax
+	mulq	%r14
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	64(%rcx),%rax
+	mulq	%r11
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	80(%rcx),%rax
+	mulq	%r13
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	72(%rcx),%rax
+	mulq	%r15
+	addq	%rax,%r8
+	movq	%r8,56(%rsp)			// c7
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movq	72(%rcx),%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	80(%rcx),%rax
+	mulq	%r15
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	88(%rcx),%rax
+	mulq	%r13
+	addq	%rax,%r9
+	movq	%r9,64(%rsp)			// c8
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movq	88(%rcx),%rax
+	mulq	%r15
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	80(%rcx),%rax
+	mulq	%r11
+	addq	%rax,%r10					// c9
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	88(%rcx),%rax
+	mulq	%r11
+	addq	%rax,%r8					// c10
+	adcq	%rdx,%r9					// c11
+
+	movq	88(%rsp),%rax
+	movq	(%rcx),%rdx
+	andq	%rax,%r12
+	andq	%rax,%r14
+	andq	%rax,%rdx
+	andq	%rax,%r13
+	andq	%rax,%r15
+	andq	%rax,%r11
+	movq	48(%rsp),%rax
+	addq	%rax,%rdx
+	movq	56(%rsp),%rax
+	adcq	%rax,%r12
+	movq	64(%rsp),%rax
+	adcq	%rax,%r14
+	adcq	%r10,%r13
+	adcq	%r8,%r15
+	adcq	%r9,%r11
+	movq	80(%rsp),%rax
+	movq	%rdx,48(%rsp)
+	movq	%r12,56(%rsp)
+	movq	%r14,64(%rsp)
+	movq	%r13,72(%rsp)
+	movq	%r15,80(%rsp)
+	movq	%r11,88(%rsp)
+
+	movq	48(%rcx),%r8
+	movq	56(%rcx),%r9
+	movq	64(%rcx),%r10
+	movq	72(%rcx),%r11
+	movq	80(%rcx),%r12
+	movq	88(%rcx),%r13
+	andq	%rax,%r8
+	andq	%rax,%r9
+	andq	%rax,%r10
+	andq	%rax,%r11
+	andq	%rax,%r12
+	andq	%rax,%r13
+	movq	48(%rsp),%rax
+	addq	%rax,%r8
+	movq	56(%rsp),%rax
+	adcq	%rax,%r9
+	movq	64(%rsp),%rax
+	adcq	%rax,%r10
+	movq	72(%rsp),%rax
+	adcq	%rax,%r11
+	movq	80(%rsp),%rax
+	adcq	%rax,%r12
+	movq	88(%rsp),%rax
+	adcq	%rax,%r13
+	movq	%r8,48(%rsp)
+	movq	%r9,56(%rsp)
+	movq	%r11,72(%rsp)
+
+// rcx[0-11] <- AL*BL
+	movq	(%rdi),%r11
+	movq	(%rsi),%rax
+	mulq	%r11
+	xorq	%r9,%r9
+	movq	%rax,(%rcx)				// c0
+	movq	%r10,64(%rsp)
+	movq	%rdx,%r8
+
+	movq	8(%rsi),%rax
+	mulq	%r11
+	xorq	%r10,%r10
+	addq	%rax,%r8
+	movq	%r12,80(%rsp)
+	adcq	%rdx,%r9
+
+	movq	8(%rdi),%r12
+	movq	(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r8
+	movq	%r8,8(%rcx)				// c1
+	adcq	%rdx,%r9
+	movq	%r13,88(%rsp)
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movq	16(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	(%rsi),%r13
+	movq	16(%rdi),%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	8(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r9
+	movq	%r9,16(%rcx)			// c2
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movq	24(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	24(%rdi),%rax
+	mulq	%r13
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	16(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	16(%rdi),%r14
+	movq	8(%rsi),%rax
+	mulq	%r14
+	addq	%rax,%r10
+	movq	%r10,24(%rcx)			// c3
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	xorq	%r10,%r10
+	movq	32(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	16(%rsi),%rax
+	mulq	%r14
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	32(%rdi),%rax
+	mulq	%r13
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	24(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	24(%rdi),%r13
+	movq	8(%rsi),%rax
+	mulq	%r13
+	addq	%rax,%r8
+	movq	%r8,32(%rcx)			// c4
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movq	40(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	16(%rsi),%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	24(%rsi),%rax
+	mulq	%r14
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	40(%rdi),%r11
+	movq	(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	32(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	32(%rdi),%r15
+	movq	8(%rsi),%rax
+	mulq	%r15
+	addq	%rax,%r9
+	movq	%r9,40(%rcx)			// c5
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movq	16(%rsi),%rax
+	mulq	%r15
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	40(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	32(%rsi),%rax
+	mulq	%r14
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	8(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	24(%rsi),%rax
+	mulq	%r13
+	addq	%rax,%r10
+	movq	%r10,48(%rcx)			// c6
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	xorq	%r10,%r10
+	movq	40(%rsi),%rax
+	mulq	%r14
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	16(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	32(%rsi),%rax
+	mulq	%r13
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	24(%rsi),%rax
+	mulq	%r15
+	addq	%rax,%r8
+	movq	%r8,56(%rcx)			// c7
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movq	24(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	32(%rsi),%rax
+	mulq	%r15
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	40(%rsi),%rax
+	mulq	%r13
+	addq	%rax,%r9
+	movq	%r9,64(%rcx)			// c8
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movq	40(%rsi),%rax
+	mulq	%r15
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	32(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r10
+	movq	%r10,72(%rcx)			// c9
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	40(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r8
+	movq	%r8,80(%rcx)			// c10
+	adcq	%rdx,%r9
+	movq	%r9,88(%rcx)			// c11
+
+// rcx[12-23] <- AH*BH
+	movq	48(%rdi),%r11
+	movq	48(%rsi),%rax
+	mulq	%r11
+	xorq	%r9,%r9
+	movq	%rax,96(%rcx)			// c0
+	movq	%rdx,%r8
+
+	movq	56(%rsi),%rax
+	mulq	%r11
+	xorq	%r10,%r10
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+
+	movq	56(%rdi),%r12
+	movq	48(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r8
+	movq	%r8,104(%rcx)			// c1
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movq	64(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	48(%rsi),%r13
+	movq	64(%rdi),%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	56(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r9
+	movq	%r9,112(%rcx)			// c2
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movq	72(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	72(%rdi),%rax
+	mulq	%r13
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	64(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	64(%rdi),%r14
+	movq	56(%rsi),%rax
+	mulq	%r14
+	addq	%rax,%r10
+	movq	%r10,120(%rcx)		// c3
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	xorq	%r10,%r10
+	movq	80(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	64(%rsi),%rax
+	mulq	%r14
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	80(%rdi),%r15
+	movq	%r13,%rax
+	mulq	%r15
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	72(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	72(%rdi),%r13
+	movq	56(%rsi),%rax
+	mulq	%r13
+	addq	%rax,%r8
+	movq	%r8,128(%rcx)			// c4
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movq	88(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	64(%rsi),%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	72(%rsi),%rax
+	mulq	%r14
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	88(%rdi),%r11
+	movq	48(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	80(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	56(%rsi),%rax
+	mulq	%r15
+	addq	%rax,%r9
+	movq	%r9,136(%rcx)			// c5
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movq	64(%rsi),%rax
+	mulq	%r15
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	88(%rsi),%rax
+	mulq	%r12
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	80(%rsi),%rax
+	mulq	%r14
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	56(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	72(%rsi),%rax
+	mulq	%r13
+	addq	%rax,%r10
+	movq	%r10,144(%rcx)		// c6
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	xorq	%r10,%r10
+	movq	88(%rsi),%rax
+	mulq	%r14
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	64(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	80(%rsi),%rax
+	mulq	%r13
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	72(%rsi),%rax
+	mulq	%r15
+	addq	%rax,%r8
+	movq	%r8,152(%rcx)			// c7
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movq	72(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	80(%rsi),%rax
+	mulq	%r15
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	88(%rsi),%rax
+	mulq	%r13
+	addq	%rax,%r9
+	movq	%r9,160(%rcx)			// c8
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	88(%rsi),%rax
+	mulq	%r15
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+
+	movq	80(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r10
+	movq	%r10,168(%rcx)		// c9
+	adcq	%rdx,%r8
+
+	movq	88(%rsi),%rax
+	mulq	%r11
+	addq	%rax,%r8
+	movq	%r8,176(%rcx)			// c10
+	adcq	$0,%rdx
+	movq	%rdx,184(%rcx)		// c11
+
+// [r8-r15,rax,rdx,rdi,[rsp]] <- (AH+AL)*(BH+BL) - AL*BL
+	movq	(%rsp),%r8
+	subq	(%rcx),%r8
+	movq	8(%rsp),%r9
+	sbbq	8(%rcx),%r9
+	movq	16(%rsp),%r10
+	sbbq	16(%rcx),%r10
+	movq	24(%rsp),%r11
+	sbbq	24(%rcx),%r11
+	movq	32(%rsp),%r12
+	sbbq	32(%rcx),%r12
+	movq	40(%rsp),%r13
+	sbbq	40(%rcx),%r13
+	movq	48(%rsp),%r14
+	sbbq	48(%rcx),%r14
+	movq	56(%rsp),%r15
+	sbbq	56(%rcx),%r15
+	movq	64(%rsp),%rax
+	sbbq	64(%rcx),%rax
+	movq	72(%rsp),%rdx
+	sbbq	72(%rcx),%rdx
+	movq	80(%rsp),%rdi
+	sbbq	80(%rcx),%rdi
+	movq	88(%rsp),%rsi
+	sbbq	88(%rcx),%rsi
+	movq	%rsi,(%rsp)
+
+// [r8-r15,rax,rdx,rdi,[rsp]] <- (AH+AL)*(BH+BL) - AL*BL - AH*BH
+	movq	96(%rcx),%rsi
+	subq	%rsi,%r8
+	movq	104(%rcx),%rsi
+	sbbq	%rsi,%r9
+	movq	112(%rcx),%rsi
+	sbbq	%rsi,%r10
+	movq	120(%rcx),%rsi
+	sbbq	%rsi,%r11
+	movq	128(%rcx),%rsi
+	sbbq	%rsi,%r12
+	movq	136(%rcx),%rsi
+	sbbq	%rsi,%r13
+	movq	144(%rcx),%rsi
+	sbbq	%rsi,%r14
+	movq	152(%rcx),%rsi
+	sbbq	%rsi,%r15
+	movq	160(%rcx),%rsi
+	sbbq	%rsi,%rax
+	movq	168(%rcx),%rsi
+	sbbq	%rsi,%rdx
+	movq	176(%rcx),%rsi
+	sbbq	%rsi,%rdi
+	movq	(%rsp),%rsi
+	sbbq	184(%rcx),%rsi
+
+// Final result
+	addq	48(%rcx),%r8
+	movq	%r8,48(%rcx)
+	adcq	56(%rcx),%r9
+	movq	%r9,56(%rcx)
+	adcq	64(%rcx),%r10
+	movq	%r10,64(%rcx)
+	adcq	72(%rcx),%r11
+	movq	%r11,72(%rcx)
+	adcq	80(%rcx),%r12
+	movq	%r12,80(%rcx)
+	adcq	88(%rcx),%r13
+	movq	%r13,88(%rcx)
+	adcq	96(%rcx),%r14
+	movq	%r14,96(%rcx)
+	adcq	104(%rcx),%r15
+	movq	%r15,104(%rcx)
+	adcq	112(%rcx),%rax
+	movq	%rax,112(%rcx)
+	adcq	120(%rcx),%rdx
+	movq	%rdx,120(%rcx)
+	adcq	128(%rcx),%rdi
+	movq	%rdi,128(%rcx)
+	adcq	136(%rcx),%rsi
+	movq	%rsi,136(%rcx)
+	movq	144(%rcx),%rax
+	adcq	$0,%rax
+	movq	%rax,144(%rcx)
+	movq	152(%rcx),%rax
+	adcq	$0,%rax
+	movq	%rax,152(%rcx)
+	movq	160(%rcx),%rax
+	adcq	$0,%rax
+	movq	%rax,160(%rcx)
+	movq	168(%rcx),%rax
+	adcq	$0,%rax
+	movq	%rax,168(%rcx)
+	movq	176(%rcx),%rax
+	adcq	$0,%rax
+	movq	%rax,176(%rcx)
+	movq	184(%rcx),%rax
+	adcq	$0,%rax
+	movq	%rax,184(%rcx)
+
+	addq	$96,%rsp					// Restoring space in stack
+	popq	%r15
+	popq	%r14
+	popq	%r13
+	popq	%r12
+	retq
+.size mul751_asm,.-mul751_asm
+
+
+//  Montgomery reduction
+//  Based on comba method
+//  Operation: c [%rsi] = a [%rdi]
+//  NOTE: a=c is not allowed
+.globl	rdc751_asm
+rdc751_asm:
+	pushq	%r12
+	pushq	%r13
+	pushq	%r14
+	pushq	%r15
+
+	movq	(%rdi),%r11
+	movabs	$p751p1_5,%rax
+	mulq	%r11
+	xorq	%r8,%r8
+	addq	40(%rdi),%rax
+	movq	%rax,40(%rsi)			// z5
+	adcq	%rdx,%r8
+
+	xorq	%r9,%r9
+	movabs	$p751p1_6,%rax
+	mulq	%r11
+	xorq	%r10,%r10
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+
+	movq	8(%rdi),%r12
+	movabs	$p751p1_5,%rax
+	mulq	%r12
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+	addq	48(%rdi),%r8
+	movq	%r8,48(%rsi)			// z6
+	adcq	$0,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movabs	$p751p1_7,%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_6,%rax
+	mulq	%r12
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	16(%rdi),%r13
+	movabs	$p751p1_5,%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+	addq	56(%rdi),%r9
+	movq	%r9,56(%rsi)			// z7
+	adcq	$0,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movabs	$p751p1_8,%rax
+	mulq	%r11
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_7,%rax
+	mulq	%r12
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_6,%rax
+	mulq	%r13
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	24(%rdi),%r14
+	movabs	$p751p1_5,%rax
+	mulq	%r14
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+	addq	64(%rdi),%r10
+	movq	%r10,64(%rsi)			// z8
+	adcq	$0,%r8
+	adcq	$0,%r9
+
+	xorq	%r10,%r10
+	movabs	$p751p1_9,%rax
+	mulq	%r11
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_8,%rax
+	mulq	%r12
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_7,%rax
+	mulq	%r13
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_6,%rax
+	mulq	%r14
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	32(%rdi),%r15
+	movabs	$p751p1_5,%rax
+	mulq	%r15
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+	addq	72(%rdi),%r8
+	movq	%r8,72(%rsi)			// z9
+	adcq	$0,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movabs	$p751p1_10,%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_9,%rax
+	mulq	%r12
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_8,%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_7,%rax
+	mulq	%r14
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_6,%rax
+	mulq	%r15
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	40(%rsi),%rcx
+	movabs	$p751p1_5,%rax
+	mulq	%rcx
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+	addq	80(%rdi),%r9
+	movq	%r9,80(%rsi)			// z10
+	adcq	$0,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movabs	$p751p1_11,%rax
+	mulq	%r11
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_10,%rax
+	mulq	%r12
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_9,%rax
+	mulq	%r13
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_8,%rax
+	mulq	%r14
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_7,%rax
+	mulq	%r15
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_6,%rax
+	mulq	%rcx
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	48(%rsi),%r11
+	movabs	$p751p1_5,%rax
+	mulq	%r11
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+	addq	88(%rdi),%r10
+	movq	%r10,88(%rsi)			// z11
+	adcq	$0,%r8
+	adcq	$0,%r9
+
+	xorq	%r10,%r10
+	movabs	$p751p1_11,%rax
+	mulq	%r12
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_10,%rax
+	mulq	%r13
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_9,%rax
+	mulq	%r14
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_8,%rax
+	mulq	%r15
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_7,%rax
+	mulq	%rcx
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_6,%rax
+	mulq	%r11
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	56(%rsi),%r12
+	movabs	$p751p1_5,%rax
+	mulq	%r12
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+	addq	96(%rdi),%r8
+	movq	%r8,(%rsi)				// z0
+	adcq	$0,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movabs	$p751p1_11,%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_10,%rax
+	mulq	%r14
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_9,%rax
+	mulq	%r15
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_8,%rax
+	mulq	%rcx
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_7,%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_6,%rax
+	mulq	%r12
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	64(%rsi),%r13
+	movabs	$p751p1_5,%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+	addq	104(%rdi),%r9
+	movq	%r9,8(%rsi)				// z1
+	adcq	$0,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movabs	$p751p1_11,%rax
+	mulq	%r14
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_10,%rax
+	mulq	%r15
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_9,%rax
+	mulq	%rcx
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_8,%rax
+	mulq	%r11
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_7,%rax
+	mulq	%r12
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_6,%rax
+	mulq	%r13
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movq	72(%rsi),%r14
+	movabs	$p751p1_5,%rax
+	mulq	%r14
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+	addq	112(%rdi),%r10
+	movq	%r10,16(%rsi)			// z2
+	adcq	$0,%r8
+	adcq	$0,%r9
+
+	xorq	%r10,%r10
+	movabs	$p751p1_11,%rax
+	mulq	%r15
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_10,%rax
+	mulq	%rcx
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_9,%rax
+	mulq	%r11
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_8,%rax
+	mulq	%r12
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_7,%rax
+	mulq	%r13
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_6,%rax
+	mulq	%r14
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movq	80(%rsi),%r15
+	movabs	$p751p1_5,%rax
+	mulq	%r15
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+	addq	120(%rdi),%r8
+	movq	%r8,24(%rsi)			// z3
+	adcq	$0,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movabs	$p751p1_11,%rax
+	mulq	%rcx
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_10,%rax
+	mulq	%r11
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_9,%rax
+	mulq	%r12
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_8,%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_7,%rax
+	mulq	%r14
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_6,%rax
+	mulq	%r15
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movq	88(%rsi),%rcx
+	movabs	$p751p1_5,%rax
+	mulq	%rcx
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+	addq	128(%rdi),%r9
+	movq	%r9,32(%rsi)			// z4
+	adcq	$0,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movabs	$p751p1_11,%rax
+	mulq	%r11
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_10,%rax
+	mulq	%r12
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_9,%rax
+	mulq	%r13
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_8,%rax
+	mulq	%r14
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_7,%rax
+	mulq	%r15
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_6,%rax
+	mulq	%rcx
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+	addq	136(%rdi),%r10
+	movq	%r10,40(%rsi)			// z5
+	adcq	$0,%r8
+	adcq	$0,%r9
+
+	xorq	%r10,%r10
+	movabs	$p751p1_11,%rax
+	mulq	%r12
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_10,%rax
+	mulq	%r13
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_9,%rax
+	mulq	%r14
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_8,%rax
+	mulq	%r15
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_7,%rax
+	mulq	%rcx
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+	addq	144(%rdi),%r8
+	movq	%r8,48(%rsi)			// z6
+	adcq	$0,%r9
+	adcq	$0,%r10
+
+	xorq	%r8,%r8
+	movabs	$p751p1_11,%rax
+	mulq	%r13
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_10,%rax
+	mulq	%r14
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_9,%rax
+	mulq	%r15
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+
+	movabs	$p751p1_8,%rax
+	mulq	%rcx
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	adcq	$0,%r8
+	addq	152(%rdi),%r9
+	movq	%r9,56(%rsi)			// z7
+	adcq	$0,%r10
+	adcq	$0,%r8
+
+	xorq	%r9,%r9
+	movabs	$p751p1_11,%rax
+	mulq	%r14
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_10,%rax
+	mulq	%r15
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+
+	movabs	$p751p1_9,%rax
+	mulq	%rcx
+	addq	%rax,%r10
+	adcq	%rdx,%r8
+	adcq	$0,%r9
+	addq	160(%rdi),%r10
+	movq	%r10,64(%rsi)			// z8
+	adcq	$0,%r8
+	adcq	$0,%r9
+
+	xorq	%r10,%r10
+	movabs	$p751p1_11,%rax
+	mulq	%r15
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_10,%rax
+	mulq	%rcx
+	addq	%rax,%r8
+	adcq	%rdx,%r9
+	adcq	$0,%r10
+	addq	168(%rdi),%r8			// z9
+	movq	%r8,72(%rsi)			// z9
+	adcq	$0,%r9
+	adcq	$0,%r10
+
+	movabs	$p751p1_11,%rax
+	mulq	%rcx
+	addq	%rax,%r9
+	adcq	%rdx,%r10
+	addq	176(%rdi),%r9			// z10
+	movq	%r9,80(%rsi)			// z10
+	adcq	$0,%r10
+	addq	184(%rdi),%r10		// z11
+	movq	%r10,88(%rsi)			// z11
+
+	popq	%r15
+	popq	%r14
+	popq	%r13
+	popq	%r12
+	retq
+.size	rdc751_asm,.-rdc751_asm
+
+//  751-bit multiprecision addition
+//  Operation: c [rdx] = a [rdi] + b [rsi]
+.globl	mp_add751_asm
+mp_add751_asm:
+	pushq	%r12
+	pushq	%r13
+	pushq	%r14
+	pushq	%r15
+	pushq	%rbx
+
+	movq	(%rdi),%r8
+	movq	8(%rdi),%r9
+	movq	16(%rdi),%r10
+	movq	24(%rdi),%r11
+	movq	32(%rdi),%r12
+	movq	40(%rdi),%r13
+	movq	48(%rdi),%r14
+	movq	56(%rdi),%r15
+	movq	64(%rdi),%rax
+	movq	72(%rdi),%rbx
+	movq	80(%rdi),%rcx
+	movq	88(%rdi),%rdi
+
+	addq	(%rsi),%r8
+	adcq	8(%rsi),%r9
+	adcq	16(%rsi),%r10
+	adcq	24(%rsi),%r11
+	adcq	32(%rsi),%r12
+	adcq	40(%rsi),%r13
+	adcq	48(%rsi),%r14
+	adcq	56(%rsi),%r15
+	adcq	64(%rsi),%rax
+	adcq	72(%rsi),%rbx
+	adcq	80(%rsi),%rcx
+	adcq	88(%rsi),%rdi
+
+	movq	%r8,(%rdx)
+	movq	%r9,8(%rdx)
+	movq	%r10,16(%rdx)
+	movq	%r11,24(%rdx)
+	movq	%r12,32(%rdx)
+	movq	%r13,40(%rdx)
+	movq	%r14,48(%rdx)
+	movq	%r15,56(%rdx)
+	movq	%rax,64(%rdx)
+	movq	%rbx,72(%rdx)
+	movq	%rcx,80(%rdx)
+	movq	%rdi,88(%rdx)
+
+	popq	%rbx
+	popq	%r15
+	popq	%r14
+	popq	%r13
+	popq	%r12
+	retq
+.size	mp_add751_asm,.-mp_add751_asm
+
+//  2x751-bit multiprecision addition
+//  Operation: c [rdx] = a [rdi] + b [rsi]
+.globl	mp_add751x2_asm
+mp_add751x2_asm:
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+	push	%rbx
+
+	movq	(%rdi),%r8
+	movq	8(%rdi),%r9
+	movq	16(%rdi),%r10
+	movq	24(%rdi),%r11
+	movq	32(%rdi),%r12
+	movq	40(%rdi),%r13
+	movq	48(%rdi),%r14
+	movq	56(%rdi),%r15
+	movq	64(%rdi),%rax
+	movq	72(%rdi),%rbx
+	movq	80(%rdi),%rcx
+
+	addq	(%rsi),%r8
+	adcq	8(%rsi),%r9
+	adcq	16(%rsi),%r10
+	adcq	24(%rsi),%r11
+	adcq	32(%rsi),%r12
+	adcq	40(%rsi),%r13
+	adcq	48(%rsi),%r14
+	adcq	56(%rsi),%r15
+	adcq	64(%rsi),%rax
+	adcq	72(%rsi),%rbx
+	adcq	80(%rsi),%rcx
+
+	movq	%r8,(%rdx)
+	movq	%r9,8(%rdx)
+	movq	%r10,16(%rdx)
+	movq	%r11,24(%rdx)
+	movq	%r12,32(%rdx)
+	movq	%r13,40(%rdx)
+	movq	%r14,48(%rdx)
+	movq	%r15,56(%rdx)
+	movq	%rax,64(%rdx)
+	movq	%rbx,72(%rdx)
+	movq	%rcx,80(%rdx)
+	movq	88(%rdi),%rax
+	adcq	88(%rsi),%rax
+	movq	%rax,88(%rdx)
+
+	movq	96(%rdi),%r8
+	movq	104(%rdi),%r9
+	movq	112(%rdi),%r10
+	movq	120(%rdi),%r11
+	movq	128(%rdi),%r12
+	movq	136(%rdi),%r13
+	movq	144(%rdi),%r14
+	movq	152(%rdi),%r15
+	movq	160(%rdi),%rax
+	movq	168(%rdi),%rbx
+	movq	176(%rdi),%rcx
+	movq	184(%rdi),%rdi
+
+	adcq	96(%rsi),%r8
+	adcq	104(%rsi),%r9
+	adcq	112(%rsi),%r10
+	adcq	120(%rsi),%r11
+	adcq	128(%rsi),%r12
+	adcq	136(%rsi),%r13
+	adcq	144(%rsi),%r14
+	adcq	152(%rsi),%r15
+	adcq	160(%rsi),%rax
+	adcq	168(%rsi),%rbx
+	adcq	176(%rsi),%rcx
+	adcq	184(%rsi),%rdi
+
+	movq	%r8,96(%rdx)
+	movq	%r9,104(%rdx)
+	movq	%r10,112(%rdx)
+	movq	%r11,120(%rdx)
+	movq	%r12,128(%rdx)
+	movq	%r13,136(%rdx)
+	movq	%r14,144(%rdx)
+	movq	%r15,152(%rdx)
+	movq	%rax,160(%rdx)
+	movq	%rbx,168(%rdx)
+	movq	%rcx,176(%rdx)
+	movq	%rdi,184(%rdx)
+
+	popq	%rbx
+	popq	%r15
+	popq	%r14
+	popq	%r13
+	popq	%r12
+	retq
+.size	mp_add751x2_asm,.-mp_add751x2_asm

--- a/SIDH_setup.c
+++ b/SIDH_setup.c
@@ -129,7 +129,7 @@ const char* SIDH_get_error_message(CRYPTO_STATUS Status)
 { // Output error/success message for a given CRYPTO_STATUS
     struct error_mapping {
         unsigned int index;
-        char*        string;
+        const char *string;
     } mapping[CRYPTO_STATUS_TYPE_SIZE] = {
         {CRYPTO_SUCCESS, CRYPTO_MSG_SUCCESS},
         {CRYPTO_ERROR, CRYPTO_MSG_ERROR},

--- a/ec_isogeny.c
+++ b/ec_isogeny.c
@@ -448,7 +448,7 @@ void xTPL(const point_proj_t P, point_proj_t Q, const f2elm_t A24, const f2elm_t
 { // Tripling of a Montgomery point in projective coordinates (X:Z).
   // Input: projective Montgomery x-coordinates P = (X:Z), where x=X/Z and Montgomery curve constant A/C.
   // Output: projective Montgomery x-coordinates Q = 3*P = (X3:Z3).
-    f2elm_t t0, t1, t2, t3, t4, t5;
+    f2elm_t t0, t1, t2, t3, t4 = {0}, t5;
 
     fp2sub751(P->X, P->Z, t2);                         // t2 = X-Z           
     fp2add751(P->X, P->Z, t3);                         // t3 = X+Z 
@@ -598,7 +598,7 @@ static void get_point_notin_2E(felm_t alpha, const f2elm_t A, const felm_t one, 
   // Output: alpha such that alpha*u = alpha*(i+4) is a good x-coordinate, which means it corresponds to a point P not in [2]E.
   //         Then, [3^eB]P has full order 2^eA.
     digit_t *A0 = (digit_t*)A[0], *A1 = (digit_t*)A[1];
-    felm_t X0, X1, x0, x1, t0, sqrt, X0_temp = {0}, X1_temp = {0}, alpha52 = {0}, alpha52_2 = {0}, alpha47 = {0}, alpha47_2 = {0};
+    felm_t X0, X1, x0, x1, t0 = {0}, sqrt, X0_temp = {0}, X1_temp = {0}, alpha52 = {0}, alpha52_2 = {0}, alpha47 = {0}, alpha47_2 = {0};
     unsigned int i;
     
     fpsub751(A0, A1, x0);                            // x0 = A0-A1
@@ -666,7 +666,7 @@ void generate_2_torsion_basis(const f2elm_t A, point_full_proj_t R1, point_full_
     felm_t *XQ = (felm_t*)Q->X,  *ZQ = (felm_t*)Q->Z;
     felm_t *Y1 = (felm_t*)R1->Y, *Y2 = (felm_t*)R2->Y;
     felm_t zero, alpha = {0};
-	f2elm_t t0, t1, one = {0};
+	f2elm_t t0 = {0}, t1, one = {0};
 	felm_t four, value47 = {0}, value52 = {0};
 
 	fpzero751(zero);
@@ -738,7 +738,7 @@ static uint64_t sqrt17[NWORDS64_FIELD] = { 0x89127CDB8966913D, 0xF788014C8C8401A
 
 static void get_X_on_curve(f2elm_t A, unsigned int* r, f2elm_t x, felm_t t1, felm_t a, felm_t b) 
 { // Elligator2 for X
-    felm_t v0, v1, r0, r1, t0, t2, t3, rsq = {0};
+    felm_t v0, v1, r0, r1, t0 = {0}, t2 = {0}, t3, rsq = {0};
     unsigned int i;
 
     fpcopy751(((felm_t*)&LIST)[(*r << 1)-2], r1);    // r1 = list[2*r-1]
@@ -816,7 +816,7 @@ static void get_X_on_curve(f2elm_t A, unsigned int* r, f2elm_t x, felm_t t1, fel
 
 static void get_pt_on_curve(f2elm_t A, unsigned int* r, f2elm_t x, f2elm_t y)
 { // Elligator2
-    felm_t t0, t1, t2, t3, a, b;
+    felm_t t0, t1, t2 = {0}, t3, a, b;
 
     get_X_on_curve(A, r, x, t1, a, b);
     fpadd751(a, t1, t0);                             // t0 = a+t1
@@ -829,12 +829,12 @@ static void get_pt_on_curve(f2elm_t A, unsigned int* r, f2elm_t x, f2elm_t y)
     fpmul751_mont(b, t1, t1);                        // t1 = t1*b
 	fpcorrection751(t0);
 	fpcorrection751(t2);
-  
+
     if (fpequal751_non_constant_time(t0, t2) == true) {
         fpcopy751(t3, y[0]);                         // y0 = t3
         fpcopy751(t1, y[1]);                         // y1 = t1;
     } else {
-        fpneg751(t3);          
+        fpneg751(t3);
         fpcopy751(t1, y[0]);                         // y0 = t1;
         fpcopy751(t3, y[1]);                         // y1 = -t3
     }
@@ -874,7 +874,7 @@ static void get_3_torsion_elt(f2elm_t A, unsigned int* r, point_proj_t P, point_
 
 
 void generate_3_torsion_basis(f2elm_t A, point_full_proj_t R1, point_full_proj_t R2, PCurveIsogenyStruct CurveIsogeny)
-{ // Produces points R1 and R2 such that {R1, R2} is a basis for E[3^239].       
+{ // Produces points R1 and R2 such that {R1, R2} is a basis for E[3^239].
   // Input:   curve constant A.
   // Outputs: R1 = (X1:Y1:Z1) and R2 = (X2:Y2:Z2).
     point_proj_t R, R3, R4;
@@ -883,13 +883,13 @@ void generate_3_torsion_basis(f2elm_t A, point_full_proj_t R1, point_full_proj_t
 	felm_t *X4 = (felm_t*)R4->X, *Z4 = (felm_t*)R4->Z;
     felm_t *X1 = (felm_t*)R1->X, *Y1 = (felm_t*)R1->Y, *Z1 = (felm_t*)R1->Z;
     felm_t *X2 = (felm_t*)R2->X, *Y2 = (felm_t*)R2->Y, *Z2 = (felm_t*)R2->Z;
-    f2elm_t u, v, c, f, t0, f0, fX, fY, Y, Y3, one = {0};
+    f2elm_t u = {0}, v, c, f, t0 = {0}, f0, fX, fY, Y, Y3, one = {0};
 	felm_t zero = {0};
-    unsigned int r = 1;         
+    unsigned int r = 1;
     unsigned int triples = 0, pts_found = 0;
 
-    get_3_torsion_elt(A, &r, R, R3, &triples, CurveIsogeny);        
-    fpcopy751(CurveIsogeny->Montgomery_one, one[0]); 
+    get_3_torsion_elt(A, &r, R, R3, &triples, CurveIsogeny);
+    fpcopy751(CurveIsogeny->Montgomery_one, one[0]);
 	fpzero751(zero);
 
     if (triples == 239) {
@@ -1591,8 +1591,8 @@ void recover_y(const publickey_t PK, point_full_proj_t phiP, point_full_proj_t p
 
 
 void compress_2_torsion(const unsigned char* PublicKeyA, unsigned char* CompressedPKA, uint64_t* a0, uint64_t* b0, uint64_t* a1, uint64_t* b1, point_t R1, point_t R2, PCurveIsogenyStruct CurveIsogeny)
-{ // 2-torsion compression                                                                          
-    point_full_proj_t P, Q, phP, phQ, phX;
+{ // 2-torsion compression
+    point_full_proj_t P = {0}, Q = {0}, phP, phQ, phX;
     point_t phiP, phiQ;
     publickey_t PK;
     digit_t* comp = (digit_t*)CompressedPKA;
@@ -1601,8 +1601,8 @@ void compress_2_torsion(const unsigned char* PublicKeyA, unsigned char* Compress
     digit_t tmp[2*NWORDS_ORDER];
 
     to_fp2mont(((f2elm_t*)PublicKeyA)[0], ((f2elm_t*)&PK)[0]);    // Converting to Montgomery representation
-    to_fp2mont(((f2elm_t*)PublicKeyA)[1], ((f2elm_t*)&PK)[1]); 
-    to_fp2mont(((f2elm_t*)PublicKeyA)[2], ((f2elm_t*)&PK)[2]); 
+    to_fp2mont(((f2elm_t*)PublicKeyA)[1], ((f2elm_t*)&PK)[1]);
+    to_fp2mont(((f2elm_t*)PublicKeyA)[2], ((f2elm_t*)&PK)[2]);
 
     recover_y(PK, phP, phQ, phX, A, CurveIsogeny);
     generate_2_torsion_basis(A, P, Q, CurveIsogeny);
@@ -1624,7 +1624,7 @@ void compress_2_torsion(const unsigned char* PublicKeyA, unsigned char* Compress
     ph2(phiP, phiQ, R1, R2, A, a0, b0, a1, b1, CurveIsogeny);
 
     if ((a0[0] & 1) == 1) {  // Storing [b1*a0inv, a1*a0inv, b0*a0inv] and setting bit384 to 0
-        inv_mod_orderA((digit_t*)a0, inv);        
+        inv_mod_orderA((digit_t*)a0, inv);
 		multiply((digit_t*)b0, inv, tmp, NWORDS_ORDER);
 		copy_words(tmp, &comp[0], NWORDS_ORDER);
 		comp[NWORDS_ORDER-1] &= (digit_t)(-1) >> 12;       // Hardcoded value
@@ -1647,7 +1647,7 @@ void compress_2_torsion(const unsigned char* PublicKeyA, unsigned char* Compress
 		comp[3*NWORDS_ORDER-1] &= (digit_t)(-1) >> 12;
 		comp[3*NWORDS_ORDER-1] |= (digit_t)1 << (sizeof(digit_t)*8 - 1);
     }
-    
+
     from_fp2mont(A, (felm_t*)&comp[3*NWORDS_ORDER]);  // Converting back from Montgomery representation
 }
 
@@ -2139,15 +2139,15 @@ void mont_twodim_scalarmult(digit_t* a, const point_t R, const point_t S, const 
 
 
 void decompress_2_torsion(const unsigned char* SecretKey, const unsigned char* CompressedPKB, point_proj_t R, f2elm_t A, PCurveIsogenyStruct CurveIsogeny)
-{ // 2-torsion decompression function                                                                          
+{ // 2-torsion decompression function
     point_t R1, R2;
-    point_full_proj_t P, Q;
+    point_full_proj_t P = {0}, Q = {0};
     digit_t* comp = (digit_t*)CompressedPKB;
     f2elm_t A24, vec[2], invs[2], one = {0};
     digit_t tmp1[2*NWORDS_ORDER], tmp2[2*NWORDS_ORDER], vone[2*NWORDS_ORDER] = {0}, mask = (digit_t)(-1);
     unsigned int bit;
 
-    mask >>= (CurveIsogeny->owordbits - CurveIsogeny->oAbits);  
+    mask >>= (CurveIsogeny->owordbits - CurveIsogeny->oAbits);
     vone[0] = 1;
     fpcopy751(CurveIsogeny->Montgomery_one, one[0]);
     to_fp2mont((felm_t*)&comp[3*NWORDS_ORDER], A);    // Converting to Montgomery representation

--- a/ec_isogeny.c
+++ b/ec_isogeny.c
@@ -1437,8 +1437,10 @@ void phn84(f2elm_t r, const f2elm_t* t_ori, const f2elm_t* LUT, const f2elm_t* L
         }
         phn21(q, LUT, LUT_0, LUT_1, one, alpha_k);  // q order 2^84 
         alpha[k] += (alpha_k[0] << (k*20));
-	    mask = ((uint64_t)1 << (k * 20))-1;
-		alpha[k + 1] += ((alpha_k[0] >> (64 - k * 20)) & mask);
+        if (k > 0) {
+            mask = ((uint64_t)1 << (k * 20))-1;
+            alpha[k + 1] += ((alpha_k[0] >> (64 - k * 20)) & mask);
+        }
 		alpha[k + 1] += (alpha_k[1] << (k * 20));
         exp84_Fp2_cycl(t_ori[k], alpha_k, one, tmp); 
         fp2mul751_mont(t, tmp, t); 

--- a/fpx.c
+++ b/fpx.c
@@ -587,7 +587,7 @@ void fp2inv751_mont(f2elm_t a)
 void fp2inv751_mont_bingcd(f2elm_t a)
 {// GF(p751^2) inversion using Montgomery arithmetic, a = (a0-i*a1)/(a0^2+a1^2)
  // This uses the binary GCD for inversion in fp and is NOT constant time!!!
-	f2elm_t t1;
+	f2elm_t t1 = {0};
 
 	fpsqr751_mont(a[0], t1[0]);             // t10 = a0^2
 	fpsqr751_mont(a[1], t1[1]);             // t11 = a1^2
@@ -677,7 +677,7 @@ void mont_n_way_inv(const f2elm_t* vec, const int n, f2elm_t* out)
 
 void sqrt_Fp2_frac(const f2elm_t u, const f2elm_t v, f2elm_t y)
 { // Computes square roots of elements in (Fp2)^2 using Hamburg's trick. 
-    felm_t t0, t1, t2, t3, t4, t;
+    felm_t t0 = {0}, t1 = {0}, t2, t3 = {0}, t4, t;
     digit_t *u0 = (digit_t*)u[0], *u1 = (digit_t*)u[1];
     digit_t *v0 = (digit_t*)v[0], *v1 = (digit_t*)v[1];
     digit_t *y0 = (digit_t*)y[0], *y1 = (digit_t*)y[1];
@@ -743,7 +743,7 @@ void sqrt_Fp2_frac(const f2elm_t u, const f2elm_t v, f2elm_t y)
 
 void sqrt_Fp2(const f2elm_t u, f2elm_t y)
 { // Computes square roots of elements in (Fp2)^2 using Hamburg's trick. 
-    felm_t t0, t1, t2, t3;
+    felm_t t0 = {0}, t1, t2, t3 = {0};
     digit_t *a  = (digit_t*)u[0], *b  = (digit_t*)u[1];
     unsigned int i;
 
@@ -913,8 +913,8 @@ void exp84_Fp2_cycl(const f2elm_t y, uint64_t* t, const felm_t one, f2elm_t res)
 
 bool is_cube_Fp2(f2elm_t u, PCurveIsogenyStruct CurveIsogeny)
 { // Check if a GF(p751^2) element is a cube.
-    f2elm_t v;
-    felm_t t0, zero = {0}, one = {0};
+    f2elm_t v = {0};
+    felm_t t0 = {0}, zero = {0}, one = {0};
     unsigned int e;
 
     fpcopy751(CurveIsogeny->Montgomery_one, one);

--- a/makefile
+++ b/makefile
@@ -43,7 +43,7 @@ ifeq "$(GENERIC)" "TRUE"
     EXTRA_OBJECTS=fp_generic.o
 else
 ifeq "$(ARCH)" "x64"
-    EXTRA_OBJECTS=fp_x64.o fp_x64_asm.o
+    EXTRA_OBJECTS=fp_x64.o fp_x64_gas_asm.o
 endif
 ifeq "$(ARCH)" "ARM64"
     EXTRA_OBJECTS=fp_arm64.o fp_arm64_asm.o
@@ -86,8 +86,8 @@ ifeq "$(ARCH)" "x64"
     fp_x64.o: AMD64/fp_x64.c
 	    $(CC) $(CFLAGS) AMD64/fp_x64.c
 
-    fp_x64_asm.o: AMD64/fp_x64_asm.S
-	    $(CC) $(CFLAGS) AMD64/fp_x64_asm.S
+    fp_x64_gas_asm.o: AMD64/fp_x64_gas_asm.S
+	    $(CC) $(CFLAGS) AMD64/fp_x64_gas_asm.S
 endif
 ifeq "$(ARCH)" "ARM64"
     fp_arm64.o: ARM64/fp_arm64.c
@@ -110,5 +110,5 @@ kex_tests.o: tests/kex_tests.c SIDH.h
 .PHONY: clean
 
 clean:
-	rm -f arith_test kex_test fp_generic.o fp_x64.o fp_x64_asm.o fp_arm64.o fp_arm64_asm.o $(OBJECTS_ALL)
+	rm -f arith_test kex_test fp_generic.o fp_x64.o fp_x64_gas_asm.o fp_arm64.o fp_arm64_asm.o $(OBJECTS_ALL)
 

--- a/tests/arith_tests.c
+++ b/tests/arith_tests.c
@@ -695,9 +695,9 @@ bool ecpoints_test(PCurveIsogenyStaticData CurveIsogenyData)
 	unsigned int pbytes = (CurveIsogenyData->pwordbits + 7)/8;      // Number of bytes in a field element 
 	unsigned int obytes = (CurveIsogenyData->owordbits + 7)/8;      // Number of bytes in an element in [1, order]
 	unsigned char *PrivateKeyA, *PublicKeyA, *PrivateKeyB, *PublicKeyB;
-	f2elm_t t0, t1;
+	f2elm_t t0 = {0}, t1;
 	f2elm_t A, C, zero, one, PK0, PK1, PK2;
-	point_full_proj_t R1, R2;
+	point_full_proj_t R1 = {0}, R2 = {0};
 	point_proj_t P1, P2, P3, P4;
 	PCurveIsogenyStruct CurveIsogeny = {0};
 	CRYPTO_STATUS Status = CRYPTO_SUCCESS;
@@ -838,7 +838,7 @@ bool ecpairing_test(PCurveIsogenyStaticData CurveIsogenyData)
 		unsigned char *PrivateKeyA, *PublicKeyA, *PrivateKeyB, *PublicKeyB;
 		f2elm_t t0, t1;
 		f2elm_t A, C, A24, C24, zero, one, PK0, PK1, PK2, pairings[5];
-		point_full_proj_t R1, R2, Q1, Q2, Q3, Q4;
+		point_full_proj_t R1 = {0}, R2 = {0}, Q1, Q2, Q3, Q4;
 		point_proj_t P1, P2, P3, P4, P5;
 		point_t S1, S2, SP, SQ;
 		PCurveIsogenyStruct CurveIsogeny = {0};
@@ -1468,12 +1468,12 @@ bool eccompress_test(PCurveIsogenyStaticData CurveIsogenyData)
 	unsigned int pbytes = (CurveIsogenyData->pwordbits + 7)/8;    // Number of bytes in a field element 
 	unsigned int obytes = (CurveIsogenyData->owordbits + 7)/8;    // Number of bytes in an element in [1, order]
 	unsigned char temp, bit, *PrivateKeyA, *PublicKeyA, *PrivateKeyB, *PublicKeyB, *CompressedPKA, *CompressedPKB, *SharedSecret1, *SharedSecret2;
-	f2elm_t A, A24, C24, C, zero, one, PK0, PK1, PK2, t0, t1;
+	f2elm_t A, A24, C24, C, zero, one, PK0 = {0}, PK1 = {0}, PK2, t0, t1;
     digit_t a0[NWORDS_ORDER], b0[NWORDS_ORDER], a1[NWORDS_ORDER], b1[NWORDS_ORDER];
     uint64_t Montgomery_rB[NWORDS64_ORDER] = {0x48062A91D3AB563D, 0x6CE572751303C2F5, 0x5D1319F3F160EC9D, 0xE35554E8C2D5623A, 0xCA29300232BC79A5, 0x8AAD843D646D78C5};  // Value -(3^239)^-1 mod 2^384
 	point_full_proj_t Q1, Q2, Q3, Q4;
 	point_proj_t P1, P2, R;
-    point_t R1, R2, R3, R4;
+    point_t R1, R2, R3 = {0}, R4 = {0};
 	PCurveIsogenyStruct CurveIsogeny = {0};
 	CRYPTO_STATUS Status = CRYPTO_SUCCESS;
 	bool passed;

--- a/tests/test_extras.c
+++ b/tests/test_extras.c
@@ -40,7 +40,7 @@ int64_t cpucycles(void)
 #elif (OS_TARGET == OS_LINUX) && (TARGET == TARGET_AMD64 || TARGET == TARGET_x86)
     unsigned int hi, lo;
 
-    asm volatile ("rdtsc\n\t" : "=a" (lo), "=d"(hi));
+    __asm__ volatile ("rdtsc\n\t" : "=a" (lo), "=d"(hi));
     return ((int64_t)lo) | (((int64_t)hi) << 32);
 #elif (OS_TARGET == OS_LINUX) && (TARGET == TARGET_ARM || TARGET == TARGET_ARM64)
     struct timespec time;
@@ -107,11 +107,11 @@ static __inline void sub751_test(felm_t a, felm_t b, felm_t c)
 void fprandom751_test(felm_t a)
 { // Generating a pseudo-random field element in [0, p751-1] 
   // SECURITY NOTE: distribution is not fully uniform. TO BE USED FOR TESTING ONLY.
-    int i, diff = 768-751;
+    int diff = 768-751;
     unsigned char* string = NULL;
 
     string = (unsigned char*)a;
-    for (i = 0; i < sizeof(digit_t)*NWORDS_FIELD; i++) {
+    for (size_t i = 0; i < sizeof(digit_t)*NWORDS_FIELD; i++) {
         *(string + i) = (unsigned char)rand();              // Obtain 768-bit number
     }
     a[NWORDS_FIELD-1] &= (((digit_t)(-1) << diff) >> diff);


### PR DESCRIPTION
Note: I somehow can't get rid of the CRLF/LF mess (using sublime on windows and git on linux).

Side note: Initializing 3d arrays and structures on the stack using `{0}` (point_proj_t, f2elm_t) fails the build when using `-Wmissing-field-initializers`, not to speak of `-Wmissing-braces` in clang's bitch-mode. This should either be done by using the default `{}` initializer or a proper `memset`.
