### PR TITLE
AMD64 asm code fixes for linux build

### DIFF
--- a/src/P503/AMD64/fp_x64_asm.S
+++ b/src/P503/AMD64/fp_x64_asm.S
@@ -83,20 +83,20 @@ fpadd503_asm:
   adc    r14, [reg_p2+48] 
   adc    r15, [reg_p2+56]
 
-  movq   rcx, p503x2_0
+  mov    rcx, p503x2_0
   sub    r8, rcx
-  movq   rcx, p503x2_1
+  mov    rcx, p503x2_1
   sbb    r9, rcx
   sbb    r10, rcx
-  movq   rcx, p503x2_3
+  mov    rcx, p503x2_3
   sbb    r11, rcx
-  movq   rcx, p503x2_4
+  mov    rcx, p503x2_4
   sbb    r12, rcx
-  movq   rcx, p503x2_5
+  mov    rcx, p503x2_5
   sbb    r13, rcx
-  movq   rcx, p503x2_6
+  mov    rcx, p503x2_6
   sbb    r14, rcx
-  movq   rcx, p503x2_7
+  mov    rcx, p503x2_7
   sbb    r15, rcx
   sbb    rax, 0
   
@@ -104,7 +104,7 @@ fpadd503_asm:
   and    rdi, rax
   mov    rsi, p503x2_1
   and    rsi, rax
-  movq   rcx, p503x2_3
+  mov    rcx, p503x2_3
   and    rcx, rax
   
   add    r8, rdi  
@@ -117,13 +117,13 @@ fpadd503_asm:
   mov    [reg_p3+24], r11 
   setc   cl
 
-  movq   r8, p503x2_4
+  mov    r8, p503x2_4
   and    r8, rax
-  movq   r9, p503x2_5
+  mov    r9, p503x2_5
   and    r9, rax
-  movq   r10, p503x2_6
+  mov    r10, p503x2_6
   and    r10, rax
-  movq   r11, p503x2_7
+  mov    r11, p503x2_7
   and    r11, rax
   
   bt     rcx, 0
@@ -177,7 +177,7 @@ fpsub503_asm:
   and    rdi, rax
   mov    rsi, p503x2_1
   and    rsi, rax
-  movq   rcx, p503x2_3
+  mov    rcx, p503x2_3
   and    rcx, rax
   
   add    r8, rdi  
@@ -190,13 +190,13 @@ fpsub503_asm:
   mov    [reg_p3+24], r11 
   setc   cl
 
-  movq   r8, p503x2_4
+  mov    r8, p503x2_4
   and    r8, rax
-  movq   r9, p503x2_5
+  mov    r9, p503x2_5
   and    r9, rax
-  movq   r10, p503x2_6
+  mov    r10, p503x2_6
   and    r10, rax
-  movq   r11, p503x2_7
+  mov    r11, p503x2_7
   and    r11, rax
   
   bt     rcx, 0
@@ -1191,7 +1191,7 @@ rdc503_asm:
   push   r15 
 
   mov    r11, [reg_p1]
-  movq   rax, p503p1_3 
+  mov    rax, p503p1_3 
   mul    r11
   xor    r8, r8
   add    rax, [reg_p1+24]
@@ -1199,14 +1199,14 @@ rdc503_asm:
   adc    r8, rdx
   
   xor    r9, r9
-  movq   rax, p503p1_4 
+  mov    rax, p503p1_4 
   mul    r11
   xor    r10, r10
   add    r8, rax
   adc    r9, rdx
 
   mov    r12, [reg_p1+8]
-  movq   rax, p503p1_3 
+  mov    rax, p503p1_3 
   mul    r12
   add    r8, rax
   adc    r9, rdx
@@ -1217,20 +1217,20 @@ rdc503_asm:
   adc    r10, 0
   
   xor    r8, r8
-  movq   rax, p503p1_5 
+  mov    rax, p503p1_5 
   mul    r11
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p503p1_4 
+  mov    rax, p503p1_4 
   mul    r12
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
   mov    r13, [reg_p1+16]
-  movq   rax, p503p1_3 
+  mov    rax, p503p1_3 
   mul    r13
   add    r9, rax
   adc    r10, rdx
@@ -1241,26 +1241,26 @@ rdc503_asm:
   adc    r8, 0
   
   xor    r9, r9
-  movq   rax, p503p1_6 
+  mov    rax, p503p1_6 
   mul    r11
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p503p1_5 
+  mov    rax, p503p1_5 
   mul    r12
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p503p1_4
+  mov    rax, p503p1_4
   mul    r13
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
   mov    r14, [reg_p2+24]
-  movq   rax, p503p1_3 
+  mov    rax, p503p1_3 
   mul    r14
   add    r10, rax
   adc    r8, rdx
@@ -1271,32 +1271,32 @@ rdc503_asm:
   adc    r9, 0
   
   xor    r10, r10
-  movq   rax, p503p1_7 
+  mov    rax, p503p1_7 
   mul    r11
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p503p1_6 
+  mov    rax, p503p1_6 
   mul    r12
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p503p1_5 
+  mov    rax, p503p1_5 
   mul    r13
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p503p1_4 
+  mov    rax, p503p1_4 
   mul    r14
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
   mov    r15, [reg_p2+32]
-  movq   rax, p503p1_3 
+  mov    rax, p503p1_3 
   mul    r15
   add    r8, rax
   adc    r9, rdx
@@ -1307,32 +1307,32 @@ rdc503_asm:
   adc    r10, 0
   
   xor    r8, r8
-  movq   rax, p503p1_7 
+  mov    rax, p503p1_7 
   mul    r12
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p503p1_6 
+  mov    rax, p503p1_6 
   mul    r13
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p503p1_5 
+  mov    rax, p503p1_5 
   mul    r14
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p503p1_4 
+  mov    rax, p503p1_4 
   mul    r15
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
   mov    rcx, [reg_p2+40]
-  movq   rax, p503p1_3 
+  mov    rax, p503p1_3 
   mul    rcx
   add    r9, rax
   adc    r10, rdx
@@ -1343,32 +1343,32 @@ rdc503_asm:
   adc    r8, 0
   
   xor    r9, r9
-  movq   rax, p503p1_7 
+  mov    rax, p503p1_7 
   mul    r13
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
 
-  movq   rax, p503p1_6 
+  mov    rax, p503p1_6 
   mul    r14
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
 
-  movq   rax, p503p1_5
+  mov    rax, p503p1_5
   mul    r15
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
 
-  movq   rax, p503p1_4
+  mov    rax, p503p1_4
   mul    rcx
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
   mov    r13, [reg_p2+48]
-  movq   rax, p503p1_3
+  mov    rax, p503p1_3
   mul    r13
   add    r10, rax
   adc    r8, rdx
@@ -1379,32 +1379,32 @@ rdc503_asm:
   adc    r9, 0
   
   xor    r10, r10
-  movq   rax, p503p1_7 
+  mov    rax, p503p1_7 
   mul    r14
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p503p1_6 
+  mov    rax, p503p1_6 
   mul    r15
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p503p1_5 
+  mov    rax, p503p1_5 
   mul    rcx
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p503p1_4 
+  mov    rax, p503p1_4 
   mul    r13
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
   mov    r14, [reg_p2+56]
-  movq   rax, p503p1_3 
+  mov    rax, p503p1_3 
   mul    r14
   add    r8, rax
   adc    r9, rdx
@@ -1415,25 +1415,25 @@ rdc503_asm:
   adc    r10, 0
   
   xor    r8, r8
-  movq   rax, p503p1_7 
+  mov    rax, p503p1_7 
   mul    r15
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p503p1_6 
+  mov    rax, p503p1_6 
   mul    rcx
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p503p1_5 
+  mov    rax, p503p1_5 
   mul    r13
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p503p1_4 
+  mov    rax, p503p1_4 
   mul    r14
   add    r9, rax
   adc    r10, rdx
@@ -1444,19 +1444,19 @@ rdc503_asm:
   adc    r8, 0
   
   xor    r9, r9
-  movq   rax, p503p1_7 
+  mov    rax, p503p1_7 
   mul    rcx
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p503p1_6 
+  mov    rax, p503p1_6 
   mul    r13
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p503p1_5 
+  mov    rax, p503p1_5 
   mul    r14
   add    r10, rax
   adc    r8, rdx
@@ -1467,13 +1467,13 @@ rdc503_asm:
   adc    r9, 0
   
   xor    r10, r10
-  movq   rax, p503p1_7 
+  mov    rax, p503p1_7 
   mul    r13
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
 
-  movq   rax, p503p1_6 
+  mov    rax, p503p1_6 
   mul    r14
   add    r8, rax
   adc    r9, rdx
@@ -1483,7 +1483,7 @@ rdc503_asm:
   adc    r9, 0
   adc    r10, 0
   
-  movq   rax, p503p1_7 
+  mov    rax, p503p1_7 
   mul    r14
   add    r9, rax
   adc    r10, rdx

--- a/src/P503/AMD64/fp_x64_asm.S
+++ b/src/P503/AMD64/fp_x64_asm.S
@@ -26,6 +26,8 @@
 #define p503x2_6   0xC08B8D7BB4EF49A0
 #define p503x2_7   0x0080CDEA83023C3C
 
+.text
+
 p503p1_nz:
 .quad    0xAC00000000000000
 .quad    0x13085BDA2211E7A0
@@ -53,7 +55,6 @@ p503p1_nz:
 #endif    
 
 
-.text
 //***********************************************************************
 //  Field addition
 //  Operation: c [reg_p3] = a [reg_p1] + b [reg_p2]
@@ -1060,7 +1061,7 @@ rdc503_asm:
     push   r15  
 
     // a[0-1] x p503p1_nz --> result: r8:r14 
-    MUL128x320_SCHOOL [reg_p1], [p503p1_nz], r8, r9, r10, r11, r12, r13, r14, rbx, rcx, r15     
+    MUL128x320_SCHOOL [reg_p1], [rip+p503p1_nz], r8, r9, r10, r11, r12, r13, r14, rbx, rcx, r15     
 
     xor    r15, r15
     add    r8, [reg_p1+24]  
@@ -1096,7 +1097,7 @@ rdc503_asm:
     mov    [reg_p1+120], r12
 
     // a[2-3] x p503p1_nz --> result: r8:r14
-    MUL128x320_SCHOOL [reg_p1+16], [p503p1_nz], r8, r9, r10, r11, r12, r13, r14, rbx, rcx, r15 
+    MUL128x320_SCHOOL [reg_p1+16], [rip+p503p1_nz], r8, r9, r10, r11, r12, r13, r14, rbx, rcx, r15 
 
     xor    r15, r15
     add    r8, [reg_p1+40]  
@@ -1126,7 +1127,7 @@ rdc503_asm:
     mov    [reg_p1+120], r10 
 
     // a[4-5] x p503p1_nz --> result: r8:r14
-    MUL128x320_SCHOOL [reg_p1+32], [p503p1_nz], r8, r9, r10, r11, r12, r13, r14, rbx, rcx, r15  
+    MUL128x320_SCHOOL [reg_p1+32], [rip+p503p1_nz], r8, r9, r10, r11, r12, r13, r14, rbx, rcx, r15  
 
     xor    r15, r15
     xor    rbx, rbx
@@ -1150,7 +1151,7 @@ rdc503_asm:
     mov    [reg_p1+120], rbx 
 
     // a[6-7] x p503p1_nz --> result: r8:r14
-    MUL128x320_SCHOOL [reg_p1+48], [p503p1_nz], r8, r9, r10, r11, r12, r13, r14, rbx, rcx, r15  
+    MUL128x320_SCHOOL [reg_p1+48], [rip+p503p1_nz], r8, r9, r10, r11, r12, r13, r14, rbx, rcx, r15  
     
     // Final result c1:c7
     add    r8, [reg_p1+72]  

--- a/src/P751/AMD64/fp_x64_asm.S
+++ b/src/P751/AMD64/fp_x64_asm.S
@@ -30,6 +30,8 @@
 #define p751x2_10  0x1C25213F2F75B8CD
 #define p751x2_11  0x0000DFCBAA83EE38
 
+.text
+
 p751p1_nz:
 .quad    0xEEB0000000000000
 .quad    0xE3EC968549F878A8
@@ -40,7 +42,6 @@ p751p1_nz:
 .quad    0x00006FE5D541F71C
 
 
-.text
 //***********************************************************************
 //  Field addition
 //  Operation: c [reg_p3] = a [reg_p1] + b [reg_p2]
@@ -1995,7 +1996,7 @@ rdc751_asm:
     push   r15  
 
     // a[0-3] x p751p1_nz --> result: [reg_p2+48], [reg_p2+56], [reg_p2+64], and rbp, r8:r14 
-    MUL256x448_SCHOOL [reg_p1], [p751p1_nz], [reg_p2+48], r8, r9, r13, r10, r14, r12, r11, rbp, rbx, rcx, r15     
+    MUL256x448_SCHOOL [reg_p1], [rip+p751p1_nz], [reg_p2+48], r8, r9, r13, r10, r14, r12, r11, rbp, rbx, rcx, r15     
 
     xor    r15, r15
     mov    rax, [reg_p2+48]
@@ -2048,7 +2049,7 @@ rdc751_asm:
     mov    [reg_p1+184], r14
 
     // a[4-7] x p751p1_nz --> result: [reg_p2+48], [reg_p2+56], [reg_p2+64], and rbp, r8:r14 
-    MUL256x448_SCHOOL [reg_p1+32], [p751p1_nz], [reg_p2+48], r8, r9, r13, r10, r14, r12, r11, rbp, rbx, rcx, r15 
+    MUL256x448_SCHOOL [reg_p1+32], [rip+p751p1_nz], [reg_p2+48], r8, r9, r13, r10, r14, r12, r11, rbp, rbx, rcx, r15 
 
     xor    r15, r15
     mov    rax, [reg_p2+48]
@@ -2089,7 +2090,7 @@ rdc751_asm:
     mov    [reg_p1+184], r14 
 
     // a[8-11] x p751p1_nz --> result: [reg_p2+48], [reg_p2+56], [reg_p2+64], and rbp, r8:r14 
-    MUL256x448_SCHOOL [reg_p1+64], [p751p1_nz], [reg_p2+48], r8, r9, r13, r10, r14, r12, r11, rbp, rbx, rcx, r15 
+    MUL256x448_SCHOOL [reg_p1+64], [rip+p751p1_nz], [reg_p2+48], r8, r9, r13, r10, r14, r12, r11, rbp, rbx, rcx, r15 
 
     // Final result c1:c11
     mov    rax, [reg_p2+48]

--- a/src/P751/AMD64/fp_x64_asm.S
+++ b/src/P751/AMD64/fp_x64_asm.S
@@ -80,20 +80,20 @@ fpadd751_asm:
   adc    rax, [reg_p2+88] 
   mov    [reg_p3+88], rax
 
-  movq   rax, p751x2_0
+  mov    rax, p751x2_0
   sub    r8, rax
-  movq   rax, p751x2_1
+  mov    rax, p751x2_1
   sbb    r9, rax
   sbb    r10, rax
   sbb    r11, rax
   sbb    r12, rax
-  movq   rax, p751x2_5
+  mov    rax, p751x2_5
   sbb    r13, rax
-  movq   rax, p751x2_6
+  mov    rax, p751x2_6
   sbb    r14, rax
-  movq   rax, p751x2_7
+  mov    rax, p751x2_7
   sbb    r15, rax
-  movq   rax, p751x2_8
+  mov    rax, p751x2_8
   sbb    rcx, rax
   mov    [reg_p3], r8
   mov    [reg_p3+8], r9
@@ -107,35 +107,35 @@ fpadd751_asm:
   mov    r8, [reg_p3+72]
   mov    r9, [reg_p3+80]
   mov    r10, [reg_p3+88]
-  movq   rax, p751x2_9
+  mov    rax, p751x2_9
   sbb    r8, rax
-  movq   rax, p751x2_10
+  mov    rax, p751x2_10
   sbb    r9, rax
-  movq   rax, p751x2_11
+  mov    rax, p751x2_11
   sbb    r10, rax
   mov    [reg_p3+72], r8
   mov    [reg_p3+80], r9
   mov    [reg_p3+88], r10
-  movq   rax, 0
+  mov    rax, 0
   sbb    rax, 0
   
   mov    rsi, p751x2_0
   and    rsi, rax
   mov    r8, p751x2_1
   and    r8, rax
-  movq   r9, p751x2_5
+  mov    r9, p751x2_5
   and    r9, rax
-  movq   r10, p751x2_6
+  mov    r10, p751x2_6
   and    r10, rax
-  movq   r11, p751x2_7
+  mov    r11, p751x2_7
   and    r11, rax
-  movq   r12, p751x2_8
+  mov    r12, p751x2_8
   and    r12, rax
-  movq   r13, p751x2_9
+  mov    r13, p751x2_9
   and    r13, rax
-  movq   r14, p751x2_10
+  mov    r14, p751x2_10
   and    r14, rax
-  movq   r15, p751x2_11
+  mov    r15, p751x2_11
   and    r15, rax
   
   add    rsi, [reg_p3]  
@@ -221,26 +221,26 @@ fpsub751_asm:
   mov    rax, [reg_p1+88]
   sbb    rax, [reg_p2+88] 
   mov    [reg_p3+88], rax
-  movq   rax, 0
+  mov    rax, 0
   sbb    rax, 0
   
   mov    rsi, p751x2_0
   and    rsi, rax
   mov    r8, p751x2_1
   and    r8, rax
-  movq   r9, p751x2_5
+  mov    r9, p751x2_5
   and    r9, rax
-  movq   r10, p751x2_6
+  mov    r10, p751x2_6
   and    r10, rax
-  movq   r11, p751x2_7
+  mov    r11, p751x2_7
   and    r11, rax
-  movq   r12, p751x2_8
+  mov    r12, p751x2_8
   and    r12, rax
-  movq   r13, p751x2_9
+  mov    r13, p751x2_9
   and    r13, rax
-  movq   r14, p751x2_10
+  mov    r14, p751x2_10
   and    r14, rax
-  movq   r15, p751x2_11
+  mov    r15, p751x2_11
   and    r15, rax
   
   mov    rax, [reg_p3]
@@ -2142,7 +2142,7 @@ rdc751_asm:
   push   r15 
 
   mov    r11, [reg_p1]
-  movq   rax, p751p1_5 
+  mov    rax, p751p1_5 
   mul    r11
   xor    r8, r8
   add    rax, [reg_p1+40]
@@ -2150,14 +2150,14 @@ rdc751_asm:
   adc    r8, rdx
   
   xor    r9, r9
-  movq   rax, p751p1_6 
+  mov    rax, p751p1_6 
   mul    r11
   xor    r10, r10
   add    r8, rax
   adc    r9, rdx
 
   mov    r12, [reg_p1+8]
-  movq   rax, p751p1_5 
+  mov    rax, p751p1_5 
   mul    r12
   add    r8, rax
   adc    r9, rdx
@@ -2168,20 +2168,20 @@ rdc751_asm:
   adc    r10, 0
   
   xor    r8, r8
-  movq   rax, p751p1_7 
+  mov    rax, p751p1_7 
   mul    r11
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_6 
+  mov    rax, p751p1_6 
   mul    r12
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
   mov    r13, [reg_p1+16]
-  movq   rax, p751p1_5 
+  mov    rax, p751p1_5 
   mul    r13
   add    r9, rax
   adc    r10, rdx
@@ -2192,26 +2192,26 @@ rdc751_asm:
   adc    r8, 0
   
   xor    r9, r9
-  movq   rax, p751p1_8 
+  mov    rax, p751p1_8 
   mul    r11
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_7 
+  mov    rax, p751p1_7 
   mul    r12
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_6 
+  mov    rax, p751p1_6 
   mul    r13
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
   mov    r14, [reg_p1+24]
-  movq   rax, p751p1_5 
+  mov    rax, p751p1_5 
   mul    r14
   add    r10, rax
   adc    r8, rdx
@@ -2222,32 +2222,32 @@ rdc751_asm:
   adc    r9, 0
   
   xor    r10, r10
-  movq   rax, p751p1_9 
+  mov    rax, p751p1_9 
   mul    r11
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_8 
+  mov    rax, p751p1_8 
   mul    r12
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_7 
+  mov    rax, p751p1_7 
   mul    r13
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_6 
+  mov    rax, p751p1_6 
   mul    r14
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
   mov    r15, [reg_p1+32]
-  movq   rax, p751p1_5 
+  mov    rax, p751p1_5 
   mul    r15
   add    r8, rax
   adc    r9, rdx
@@ -2258,38 +2258,38 @@ rdc751_asm:
   adc    r10, 0
   
   xor    r8, r8
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    r11
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_9 
+  mov    rax, p751p1_9 
   mul    r12
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_8 
+  mov    rax, p751p1_8 
   mul    r13
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_7 
+  mov    rax, p751p1_7 
   mul    r14
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_6 
+  mov    rax, p751p1_6 
   mul    r15
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
   mov    rcx, [reg_p2+40]
-  movq   rax, p751p1_5 
+  mov    rax, p751p1_5 
   mul    rcx
   add    r9, rax
   adc    r10, rdx
@@ -2300,44 +2300,44 @@ rdc751_asm:
   adc    r8, 0
   
   xor    r9, r9
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    r11
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    r12
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_9 
+  mov    rax, p751p1_9 
   mul    r13
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_8 
+  mov    rax, p751p1_8 
   mul    r14
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_7 
+  mov    rax, p751p1_7 
   mul    r15
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_6 
+  mov    rax, p751p1_6 
   mul    rcx
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
   mov    r11, [reg_p2+48]
-  movq   rax, p751p1_5 
+  mov    rax, p751p1_5 
   mul    r11
   add    r10, rax
   adc    r8, rdx
@@ -2348,44 +2348,44 @@ rdc751_asm:
   adc    r9, 0
   
   xor    r10, r10
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    r12
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    r13
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_9 
+  mov    rax, p751p1_9 
   mul    r14
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_8 
+  mov    rax, p751p1_8 
   mul    r15
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_7 
+  mov    rax, p751p1_7 
   mul    rcx
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_6 
+  mov    rax, p751p1_6 
   mul    r11
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
   mov    r12, [reg_p2+56]
-  movq   rax, p751p1_5 
+  mov    rax, p751p1_5 
   mul    r12
   add    r8, rax
   adc    r9, rdx
@@ -2396,44 +2396,44 @@ rdc751_asm:
   adc    r10, 0
   
   xor    r8, r8
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    r13
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
 
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    r14
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
 
-  movq   rax, p751p1_9
+  mov    rax, p751p1_9
   mul    r15
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
 
-  movq   rax, p751p1_8
+  mov    rax, p751p1_8
   mul    rcx
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
 
-  movq   rax, p751p1_7
+  mov    rax, p751p1_7
   mul    r11
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
 
-  movq   rax, p751p1_6
+  mov    rax, p751p1_6
   mul    r12
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
   mov    r13, [reg_p2+64]
-  movq   rax, p751p1_5
+  mov    rax, p751p1_5
   mul    r13
   add    r9, rax
   adc    r10, rdx
@@ -2444,44 +2444,44 @@ rdc751_asm:
   adc    r8, 0
   
   xor    r9, r9
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    r14
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    r15
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_9 
+  mov    rax, p751p1_9 
   mul    rcx
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_8 
+  mov    rax, p751p1_8 
   mul    r11
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_7 
+  mov    rax, p751p1_7 
   mul    r12
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_6 
+  mov    rax, p751p1_6 
   mul    r13
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
   mov    r14, [reg_p2+72]
-  movq   rax, p751p1_5 
+  mov    rax, p751p1_5 
   mul    r14
   add    r10, rax
   adc    r8, rdx
@@ -2492,44 +2492,44 @@ rdc751_asm:
   adc    r9, 0
   
   xor    r10, r10
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    r15
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    rcx
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_9 
+  mov    rax, p751p1_9 
   mul    r11
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_8 
+  mov    rax, p751p1_8 
   mul    r12
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_7 
+  mov    rax, p751p1_7 
   mul    r13
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_6 
+  mov    rax, p751p1_6 
   mul    r14
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
   mov    r15, [reg_p2+80]
-  movq   rax, p751p1_5 
+  mov    rax, p751p1_5 
   mul    r15
   add    r8, rax
   adc    r9, rdx
@@ -2540,44 +2540,44 @@ rdc751_asm:
   adc    r10, 0
   
   xor    r8, r8
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    rcx
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    r11
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_9 
+  mov    rax, p751p1_9 
   mul    r12
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_8 
+  mov    rax, p751p1_8 
   mul    r13
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_7 
+  mov    rax, p751p1_7 
   mul    r14
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_6 
+  mov    rax, p751p1_6 
   mul    r15
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
   mov    rcx, [reg_p2+88]
-  movq   rax, p751p1_5 
+  mov    rax, p751p1_5 
   mul    rcx
   add    r9, rax
   adc    r10, rdx
@@ -2588,37 +2588,37 @@ rdc751_asm:
   adc    r8, 0
   
   xor    r9, r9
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    r11
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    r12
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_9 
+  mov    rax, p751p1_9 
   mul    r13
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_8 
+  mov    rax, p751p1_8 
   mul    r14
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_7 
+  mov    rax, p751p1_7 
   mul    r15
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_6 
+  mov    rax, p751p1_6 
   mul    rcx
   add    r10, rax
   adc    r8, rdx
@@ -2629,31 +2629,31 @@ rdc751_asm:
   adc    r9, 0
   
   xor    r10, r10
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    r12
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    r13
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_9 
+  mov    rax, p751p1_9 
   mul    r14
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_8 
+  mov    rax, p751p1_8 
   mul    r15
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
   
-  movq   rax, p751p1_7 
+  mov    rax, p751p1_7 
   mul    rcx
   add    r8, rax
   adc    r9, rdx
@@ -2664,25 +2664,25 @@ rdc751_asm:
   adc    r10, 0
   
   xor    r8, r8
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    r13
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    r14
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_9 
+  mov    rax, p751p1_9 
   mul    r15
   add    r9, rax
   adc    r10, rdx
   adc    r8, 0
   
-  movq   rax, p751p1_8 
+  mov    rax, p751p1_8 
   mul    rcx
   add    r9, rax
   adc    r10, rdx
@@ -2693,19 +2693,19 @@ rdc751_asm:
   adc    r8, 0
   
   xor    r9, r9
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    r14
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    r15
   add    r10, rax
   adc    r8, rdx
   adc    r9, 0
   
-  movq   rax, p751p1_9 
+  mov    rax, p751p1_9 
   mul    rcx
   add    r10, rax
   adc    r8, rdx
@@ -2716,13 +2716,13 @@ rdc751_asm:
   adc    r9, 0
   
   xor    r10, r10
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    r15
   add    r8, rax
   adc    r9, rdx
   adc    r10, 0
 
-  movq   rax, p751p1_10 
+  mov    rax, p751p1_10 
   mul    rcx
   add    r8, rax
   adc    r9, rdx
@@ -2732,7 +2732,7 @@ rdc751_asm:
   adc    r9, 0
   adc    r10, 0
   
-  movq   rax, p751p1_11 
+  mov    rax, p751p1_11 
   mul    rcx
   add    r9, rax
   adc    r10, rdx


### PR DESCRIPTION
Two commits aimed at fixing the following issues:
- the asm code does not compile using clang-6.0 because it uses movq which is no more tolerated by clang in intel asm.
- the asm code does not allow to build position independent code library.
