### PR TITLE
Add gitignores for build output from Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,17 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+lib503/
+lib610/
+objs/
+objs434/
+objs434comp/
+objs503/
+objs503comp/
+objs610/
+objs610comp/
+objs751/
+objs751comp/
 
 # Visual Studio 2015 cache/options directory
 .vs/


### PR DESCRIPTION
When building using the provided Makefile, it creates a lot of directories containing built object code. This adds the build output folders to the gitignore file.

Note: there is a lot of things in the gitignore already that seem like they might not be relevant to this project (see existing file), should it maybe be cleaned out at some point?