### PR TITLE
If ARCH=M1, set ADDITIONAL_SETTINGS="-mcpu=apple-a14"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ endif
 ifeq "$(ARCHITECTURE)" "_S390X_"
 	ADDITIONAL_SETTINGS=-march=z10
 endif
+ifeq "$(ARCH)" "M1"
+	ADDITIONAL_SETTINGS=-mcpu=apple-a14
+endif
 
 VALGRIND_CFLAGS=
 ifeq "$(DO_VALGRIND_CHECK)" "TRUE"


### PR DESCRIPTION
Works nicely for clang and gcc on an M1 Macbook Air